### PR TITLE
fix: review round 1 — tier tie-breaking and auto-import cleanup

### DIFF
--- a/client/src/pages/operator/InsightsPage.jsx
+++ b/client/src/pages/operator/InsightsPage.jsx
@@ -309,11 +309,12 @@ export default function InsightsPage() {
               <div className="mb-6">
                 <h2 className="font-display text-lg font-semibold text-dark mb-4">Creator Tier Performance</h2>
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                  {TIER_ORDER.filter((t) => data.creatorTierPerformance?.[t]).map((tier) => {
+                  {TIER_ORDER.filter((t) => data.creatorTierPerformance?.[t]).map((tier, idx, arr) => {
                     const tierData = data.creatorTierPerformance[tier];
-                    const allRates = Object.values(data.creatorTierPerformance).map((d) => d.avgAcceptanceRate);
+                    const allRates = arr.map((t) => data.creatorTierPerformance[t].avgAcceptanceRate);
                     const maxRate = Math.max(...allRates);
-                    const isBest = tierData.avgAcceptanceRate === maxRate && maxRate > 0;
+                    const firstBest = arr.find((t) => data.creatorTierPerformance[t].avgAcceptanceRate === maxRate);
+                    const isBest = tier === firstBest && maxRate > 0;
                     return <TierCard key={tier} tier={tier} data={tierData} isBest={isBest} />;
                   })}
                   {Object.keys(data.creatorTierPerformance || {}).length === 0 && (

--- a/server/src/routes/brands.js
+++ b/server/src/routes/brands.js
@@ -288,32 +288,24 @@ router.post("/auto-import", async (req, res, next) => {
       urlType = "yelp";
     }
 
-    // Step 1: Try AI-powered analysis if available
-    if (openaiAvailable()) {
-      const aiResult = await analyzeBrandFromUrl(url);
-      return res.json({
-        source: "ai",
-        urlType,
-        data: aiResult,
-      });
+    // Step 1: Check for known business fallback first (instant, no API call)
+    if (!openaiAvailable()) {
+      const fallbackData = findFallbackMatch(url);
+      if (fallbackData) {
+        return res.json({
+          source: "fallback",
+          urlType,
+          data: fallbackData,
+        });
+      }
     }
 
-    // Step 2: Fall back to known businesses if no AI
-    const fallbackData = findFallbackMatch(url);
-    if (fallbackData) {
-      return res.json({
-        source: "fallback",
-        urlType,
-        data: fallbackData,
-      });
-    }
-
-    // Step 3: No AI and no known fallback — use URL-based extraction with sensible defaults
-    const extractedData = await analyzeBrandFromUrl(url);
+    // Step 2: AI analysis (falls back to URL-based extraction internally if no API key)
+    const result = await analyzeBrandFromUrl(url);
     return res.json({
-      source: "fallback",
+      source: openaiAvailable() ? "ai" : "fallback",
       urlType,
-      data: extractedData,
+      data: result,
     });
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
- Fix InsightsPage "Best Performer" badge showing on multiple tiers when they tie — now only the first (by TIER_ORDER) gets the badge
- Simplify `brands.js` auto-import handler: removed redundant `openaiAvailable()` gate + duplicate `analyzeBrandFromUrl()` call, consolidating into a single clean flow

## Review context
Post-merge review of PR #7. These are non-critical improvements found during full code review.

## Test plan
- [x] Server boots cleanly (`/api/health` returns ok)
- [x] Client compiles without errors
- [ ] Verify InsightsPage with seeded data shows exactly one "Best Performer" badge
- [ ] Verify auto-import still works for Google Maps/Yelp URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)