### PR TITLE
fix: remove dead import and fix fragile brief-project matching

### DIFF
--- a/client/src/components/operator/DataExport.jsx
+++ b/client/src/components/operator/DataExport.jsx
@@ -27,10 +27,10 @@ export default function DataExport() {
       const briefs = briefsRes.data.briefs || [];
       const projects = projectsRes.data.projects || [];
 
-      const projectByBriefTitle = {};
+      const projectByBriefId = {};
       for (const p of projects) {
-        const title = p.application?.brief?.title;
-        if (title) projectByBriefTitle[title] = p;
+        const briefId = p.application?.brief?.id;
+        if (briefId) projectByBriefId[briefId] = p;
       }
 
       const headers = [
@@ -46,7 +46,7 @@ export default function DataExport() {
       ];
 
       const rows = briefs.map((b) => {
-        const proj = projectByBriefTitle[b.title];
+        const proj = projectByBriefId[b.id];
         return {
           'Brief Title': b.title || '',
           'Status': b.status || '',

--- a/client/src/pages/operator/BriefDetail.jsx
+++ b/client/src/pages/operator/BriefDetail.jsx
@@ -6,7 +6,6 @@ import Btn from '../../components/common/Btn';
 import StatusBadge from '../../components/common/StatusBadge';
 import FadeIn from '../../components/marketing/FadeIn';
 import ApplicationFilters, { getCreatorTier } from '../../components/operator/ApplicationFilters';
-import ApplicationScoreBadge from '../../components/operator/ApplicationScoreBadge';
 
 const CAMPAIGN_GOAL_LABELS = {
   EVENT_PROMO: 'Event Promo',


### PR DESCRIPTION
## Summary
- Remove unused `ApplicationScoreBadge` import from `BriefDetail.jsx` — the component defines its own `MatchScoreBadge` inline and never uses the imported one
- Fix `DataExport.jsx` to match projects to briefs by ID instead of title string, preventing incorrect CSV data when two briefs share the same title

## Test plan
- [ ] Verify BriefDetail page renders correctly without the removed import
- [ ] Verify CSV export correctly maps projects to briefs (especially with duplicate titles)
- [ ] Dev server boots clean, health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)