### PR TITLE
fix: add auth to admin reseed endpoint

### DIFF
--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -105,6 +105,17 @@ async function requireCreatorToken(req, res, next) {
   }
 }
 
+/**
+ * Requires the authenticated user to have the ADMIN role.
+ * Must be used after requireAuth.
+ */
+function requireAdmin(req, res, next) {
+  if (req.user.role !== "ADMIN") {
+    return res.status(403).json({ error: "Admin access required." });
+  }
+  next();
+}
+
 function requireAgencyWithProfile(req, res, next) {
   if (req.user.role !== "AGENCY") {
     return res.status(403).json({ error: "Only agencies can perform this action" });
@@ -116,4 +127,4 @@ function requireAgencyWithProfile(req, res, next) {
   next();
 }
 
-module.exports = { requireAuth, optionalAuth, requireOperatorWithBrand, requireCreatorToken, requireAgencyWithProfile };
+module.exports = { requireAuth, optionalAuth, requireOperatorWithBrand, requireCreatorToken, requireAgencyWithProfile, requireAdmin };

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -1,12 +1,17 @@
 const express = require("express");
 const router = express.Router();
+const { requireAuth, requireAdmin } = require("../middleware/auth");
 
 /**
  * POST /api/admin/reseed
  * Re-runs the seed script to reset all demo data to its starting state.
- * No auth required — this is a demo-only admin endpoint.
+ * Requires ADMIN role. Disabled entirely in production.
  */
-router.post("/reseed", async (req, res, next) => {
+router.post("/reseed", requireAuth, requireAdmin, async (req, res, next) => {
+  if (process.env.NODE_ENV === "production") {
+    return res.status(403).json({ error: "Reseed is disabled in production." });
+  }
+
   try {
     console.log("[Admin] Reseed requested — running seed script...");
 


### PR DESCRIPTION
## Summary
- Add `requireAuth` + `requireAdmin` middleware to `POST /admin/reseed` so only authenticated users with `ADMIN` role can trigger a database reseed
- Block the endpoint entirely when `NODE_ENV=production` (returns 403)
- Add reusable `requireAdmin` middleware to `server/src/middleware/auth.js`

## Test plan
- [ ] Send `POST /api/admin/reseed` with no `x-user-id` header — expect 401
- [ ] Send `POST /api/admin/reseed` with a valid OPERATOR user — expect 403 "Admin access required"
- [ ] Send `POST /api/admin/reseed` with a valid ADMIN user — expect 200 success
- [ ] Set `NODE_ENV=production` and send with ADMIN user — expect 403 "Reseed is disabled in production"

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)