### PR TITLE
feat: populate CampaignData on project completion

### DIFF
--- a/server/src/routes/projects.js
+++ b/server/src/routes/projects.js
@@ -272,11 +272,12 @@ router.post("/:id/complete", requireAuth, requireOperatorWithBrand, async (req, 
     }
 
     // Update project status
+    const completedAt = new Date();
     const updatedProject = await prisma.project.update({
       where: { id: project.id },
       data: {
         status: "COMPLETED",
-        completedAt: new Date(),
+        completedAt,
       },
       include: {
         application: { include: { brief: true } },
@@ -288,6 +289,72 @@ router.post("/:id/complete", requireAuth, requireOperatorWithBrand, async (req, 
     // Release escrow via payout
     if (project.transaction) {
       await createPayout(project.id, project.transaction.creatorPayout);
+    }
+
+    // ── Create CampaignData record for insights ──
+    try {
+      const brief = updatedProject.application?.brief;
+      const brandProfile = updatedProject.brandProfile;
+      const application = updatedProject.application;
+
+      if (brief && brandProfile) {
+        // Count applications for this brief
+        const numberOfApplications = await prisma.application.count({
+          where: { briefId: brief.id },
+        });
+
+        // Calculate time to first application (in minutes)
+        const firstApplication = await prisma.application.findFirst({
+          where: { briefId: brief.id },
+          orderBy: { createdAt: "asc" },
+          select: { createdAt: true },
+        });
+        const timeToFirstApplication = firstApplication
+          ? Math.round((firstApplication.createdAt.getTime() - brief.createdAt.getTime()) / 60000)
+          : null;
+
+        // Derive creator tier from follower count
+        const followerCount = application?.followerCount || 0;
+        let selectedCreatorTier;
+        if (followerCount >= 100000) {
+          selectedCreatorTier = "MACRO";
+        } else if (followerCount >= 50000) {
+          selectedCreatorTier = "MID";
+        } else if (followerCount >= 10000) {
+          selectedCreatorTier = "MICRO";
+        } else {
+          selectedCreatorTier = "NANO";
+        }
+
+        // Check if content was approved (project reached APPROVED -> COMPLETED)
+        const wasContentApproved = true; // project must be APPROVED before completing
+
+        // Count revisions requested on this project
+        const revisionsRequested = updatedProject.revisionsUsed || 0;
+
+        await prisma.campaignData.create({
+          data: {
+            briefId: brief.id,
+            brandProfileId: brandProfile.id,
+            campaignGoal: brief.campaignGoal,
+            contentTypes: brief.contentTypes || [],
+            compensationType: updatedProject.compensationType,
+            compensationAmount: updatedProject.price || null,
+            neighborhood: brandProfile.neighborhood,
+            city: brandProfile.city || "Evanston",
+            cuisineTypes: brandProfile.cuisineTypes || [],
+            numberOfApplications,
+            timeToFirstApplication,
+            selectedCreatorTier,
+            wasContentApproved,
+            revisionsRequested,
+            completedAt,
+          },
+        });
+      }
+    } catch (campaignDataErr) {
+      // Log but don't fail the completion — insights are non-critical
+      console.error("[projects/:id/complete] Failed to create CampaignData:", campaignDataErr);
     }
 
     res.json({ project: updatedProject });


### PR DESCRIPTION
## Summary
- When a project is marked COMPLETED via `POST /api/projects/:id/complete`, a `CampaignData` record is now created automatically from the project, its application, brief, and brand profile
- Populates all analytics fields: `campaignGoal`, `contentTypes`, `compensationType`, `compensationAmount`, `neighborhood`, `city`, `cuisineTypes`, `numberOfApplications`, `timeToFirstApplication`, `selectedCreatorTier`, `wasContentApproved`, `revisionsRequested`, `completedAt`
- Creator tier is derived from follower count: NANO (<10K), MICRO (10-50K), MID (50-100K), MACRO (100K+)
- CampaignData creation is wrapped in try/catch so it never blocks the completion flow — failures are logged but non-fatal

Closes #13

## Test plan
- [ ] Complete a project via the UI (approve draft, then mark complete) and verify a `CampaignData` row is created in the database
- [ ] Complete 3 projects for the same brand and verify the Insights page unlocks
- [ ] Verify insights data (acceptance rates, tier performance, neighborhood benchmarks) reflects actual completed campaigns, not just seed data
- [ ] Verify that if CampaignData creation fails for any reason, the project still completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)