### PR TITLE
feat: multi-step brief creation form with progress indicator

### DIFF
--- a/client/src/pages/operator/CreateBrief.jsx
+++ b/client/src/pages/operator/CreateBrief.jsx
@@ -232,7 +232,7 @@ function StepBasics({ form, updateField, toggleContentType, fieldErrors, handleS
         <select
           value={form.compensationType}
           onChange={(e) => updateField('compensationType', e.target.value)}
-          className={selectClass}
+          className={`${selectClass} ${fieldErrors.compensationType ? 'border-red-400 focus:ring-red-200' : ''}`}
         >
           <option value="">Select compensation...</option>
           {COMPENSATION_TYPES.map((ct) => (
@@ -241,6 +241,7 @@ function StepBasics({ form, updateField, toggleContentType, fieldErrors, handleS
             </option>
           ))}
         </select>
+        {fieldErrors.compensationType && <p className="mt-1 text-xs text-red-600 font-body">{fieldErrors.compensationType}</p>}
       </div>
 
       {/* Compensation Amount (conditional) */}
@@ -258,8 +259,9 @@ function StepBasics({ form, updateField, toggleContentType, fieldErrors, handleS
               updateField('compensationAmount', e.target.value)
             }
             placeholder="e.g. 150"
-            className={inputClass}
+            className={`${inputClass} ${fieldErrors.compensationAmount ? 'border-red-400 focus:ring-red-200' : ''}`}
           />
+          {fieldErrors.compensationAmount && <p className="mt-1 text-xs text-red-600 font-body">{fieldErrors.compensationAmount}</p>}
           <p className="text-xs text-muted font-body mt-1">
             Enter the dollar amount. This will be stored as cents on the backend.
           </p>
@@ -340,7 +342,7 @@ function StepCreativeDetails({ form, updateField, fieldErrors }) {
         <select
           value={form.usageRights}
           onChange={(e) => updateField('usageRights', e.target.value)}
-          className={selectClass}
+          className={`${selectClass} ${fieldErrors.usageRights ? 'border-red-400 focus:ring-red-200' : ''}`}
         >
           <option value="">Select usage rights...</option>
           {USAGE_RIGHTS.map((ur) => (
@@ -349,6 +351,7 @@ function StepCreativeDetails({ form, updateField, fieldErrors }) {
             </option>
           ))}
         </select>
+        {fieldErrors.usageRights && <p className="mt-1 text-xs text-red-600 font-body">{fieldErrors.usageRights}</p>}
       </div>
 
       {/* Location Requirement */}
@@ -361,7 +364,7 @@ function StepCreativeDetails({ form, updateField, fieldErrors }) {
           onChange={(e) =>
             updateField('locationRequirement', e.target.value)
           }
-          className={selectClass}
+          className={`${selectClass} ${fieldErrors.locationRequirement ? 'border-red-400 focus:ring-red-200' : ''}`}
         >
           <option value="">Select location requirement...</option>
           {LOCATION_REQUIREMENTS.map((lr) => (
@@ -370,6 +373,7 @@ function StepCreativeDetails({ form, updateField, fieldErrors }) {
             </option>
           ))}
         </select>
+        {fieldErrors.locationRequirement && <p className="mt-1 text-xs text-red-600 font-body">{fieldErrors.locationRequirement}</p>}
       </div>
 
       {/* Additional Notes */}


### PR DESCRIPTION
## Summary
- Split the 14-field CreateBrief form into 3 logical steps: **Basics** (title, goal, content types, deliverables, compensation), **Creative Details** (direction, dos/donts, deadline, usage rights, location, notes), and **Review & Publish** (portal-style preview with save/publish actions)
- Added a visual progress stepper with clickable step circles, completion checkmarks, and connector lines using the existing design system (accent color, font-display, rounded-xl, card class)
- Implemented localStorage auto-save (debounced 1s) that restores form state on page load and clears on successful publish
- Step 3 preview matches the portal BriefDetailView layout: details grid, content type pills, dos/donts cards, creative direction section

## What changed
- `client/src/pages/operator/CreateBrief.jsx` -- refactored from single-page form into multi-step form with ProgressStepper, StepBasics, StepCreativeDetails, and StepReviewPublish components (all in same file)

## Acceptance criteria
- [x] Form split into logical steps with visible progress
- [x] Users can navigate back/forward between steps
- [x] Draft auto-saves so browser crash doesn't lose work
- [x] Final step shows brief preview matching portal appearance
- [x] Existing save-as-draft and publish functionality preserved
- [x] AI suggestions feature preserved on step 1

## Test plan
- [ ] Navigate through all 3 steps, verify progress stepper updates correctly
- [ ] Click completed step circles to navigate back, verify form state is preserved
- [ ] Fill step 1 partially, try to advance -- verify validation blocks with field-level errors
- [ ] Fill all required fields, advance through steps, verify step 3 preview renders correctly
- [ ] Close the browser mid-form, reopen CreateBrief -- verify localStorage restores the draft
- [ ] Publish a brief from step 3, verify localStorage is cleared and redirect works
- [ ] Save as draft from step 3, verify it works the same as before
- [ ] Test on mobile viewport -- verify stepper and form layout are responsive
- [ ] Verify AI suggestion cards still appear on step 1 after selecting a campaign goal

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)