### PR TITLE
fix: notification badge uses accent color and 30s polling

### DIFF
--- a/client/src/components/layout/NotificationBell.jsx
+++ b/client/src/components/layout/NotificationBell.jsx
@@ -30,7 +30,7 @@ export default function NotificationBell() {
 
   useEffect(() => {
     fetchUnread();
-    const interval = setInterval(fetchUnread, 15000);
+    const interval = setInterval(fetchUnread, 30000);
     return () => clearInterval(interval);
   }, []);
 
@@ -91,7 +91,7 @@ export default function NotificationBell() {
           <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
         </svg>
         {unread > 0 && (
-          <span className="absolute -top-0.5 -right-0.5 w-4.5 h-4.5 min-w-[18px] bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none px-1">
+          <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] bg-accent text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none px-1">
             {unread > 9 ? '9+' : unread}
           </span>
         )}


### PR DESCRIPTION
## Summary
- Updated notification bell badge color from `bg-red-500` to `bg-accent` (`#B85042`) to match the design system
- Fixed non-standard Tailwind classes (`w-4.5`/`h-4.5`) with proper arbitrary value syntax (`h-[18px]`)
- Changed polling interval from 15s to 30s as specified in the design requirements

**Note:** The `NotificationBell` component already had all the core functionality in place (unread count fetching, badge with "9+" cap, badge hidden at 0, updates on read). This PR aligns the styling with the design system and adjusts the polling frequency.

Closes #30

## Test plan
- [ ] Verify badge appears on bell icon when there are unread notifications
- [ ] Verify badge uses the accent color (#B85042) not generic red
- [ ] Verify badge shows "9+" when count exceeds 9
- [ ] Verify badge disappears when count is 0
- [ ] Verify badge updates when notifications are marked as read

🤖 Generated with [Claude Code](https://claude.com/claude-code)